### PR TITLE
fix: add docker profile to JwtDecoder bean

### DIFF
--- a/src/main/java/com/accountabilityatlas/videoservice/config/SecurityConfig.java
+++ b/src/main/java/com/accountabilityatlas/videoservice/config/SecurityConfig.java
@@ -49,7 +49,7 @@ public class SecurityConfig {
   }
 
   @Bean
-  @Profile("local")
+  @Profile({"local", "docker"})
   public JwtDecoder localJwtDecoder() {
     return token ->
         new Jwt(

--- a/src/main/java/com/accountabilityatlas/videoservice/event/VideoRejectedEvent.java
+++ b/src/main/java/com/accountabilityatlas/videoservice/event/VideoRejectedEvent.java
@@ -11,5 +11,4 @@ import java.util.UUID;
  * @param reason the reason for rejection
  * @param timestamp when the rejection occurred
  */
-public record VideoRejectedEvent(
-    UUID videoId, UUID reviewerId, String reason, Instant timestamp) {}
+public record VideoRejectedEvent(UUID videoId, UUID reviewerId, String reason, Instant timestamp) {}


### PR DESCRIPTION
## Summary

- Add `docker` to the `@Profile` annotation on `JwtDecoder` bean
- Formatting fix for `VideoRejectedEvent`

Fixes #10

## Test plan

- [x] Rebuild Docker image with `./gradlew jibDockerBuild`
- [x] Verify service starts successfully with `SPRING_PROFILES_ACTIVE=docker`

🤖 Generated with [Claude Code](https://claude.ai/code)