### PR TITLE
fix: remove maxLength from youtubeUrl to fix validation error

### DIFF
--- a/docs/api-specification.yaml
+++ b/docs/api-specification.yaml
@@ -658,7 +658,6 @@ components:
         youtubeUrl:
           type: string
           format: uri
-          maxLength: 200
           description: |
             Full YouTube URL. Supported formats:
             - https://www.youtube.com/watch?v=VIDEO_ID


### PR DESCRIPTION
## Summary

Remove `maxLength: 200` from the `youtubeUrl` field in the OpenAPI spec to fix validation error.

Closes #20

## Root Cause

The OpenAPI generator creates `java.net.URI` type for `format: uri`, but also adds `@Size(max = 200)` for `maxLength`. The `@Size` validator only works with String, Collection, Map, and arrays - not URI, causing:

```
jakarta.validation.UnexpectedTypeException: HV000030: No validator could be found for constraint 'jakarta.validation.constraints.Size' validating type 'java.net.URI'
```

## Test plan

- [x] Unit tests pass
- [x] `POST /videos` without auth now returns 403 (was 500)
- [x] Validation errors now return proper responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)