### PR TITLE
fix: suppress SQS JavaType header for cross-service deserialization

### DIFF
--- a/src/main/java/com/accountabilityatlas/videoservice/config/SqsConfig.java
+++ b/src/main/java/com/accountabilityatlas/videoservice/config/SqsConfig.java
@@ -1,0 +1,60 @@
+package com.accountabilityatlas.videoservice.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.awspring.cloud.sqs.operations.SqsTemplate;
+import io.awspring.cloud.sqs.support.converter.SqsMessagingMessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+
+/**
+ * SQS configuration for cross-service message handling.
+ *
+ * <p>By default, Spring Cloud AWS SQS adds a {@code JavaType} message attribute containing the
+ * fully-qualified class name of the payload. When producer and consumer services define the same
+ * event record in different packages, the consumer cannot load the producer's class, causing
+ * deserialization to fail with {@code ClassNotFoundException}.
+ *
+ * <p>This configuration disables the {@code JavaType} header on both the sending and receiving
+ * sides:
+ *
+ * <ul>
+ *   <li><b>Producer ({@link SqsTemplate})</b>: {@code setPayloadTypeHeaderValueFunction} returns
+ *       null, suppressing the header.
+ *   <li><b>Consumer ({@link SqsMessagingMessageConverter})</b>: {@code setPayloadTypeMapper}
+ *       returns null, forcing Jackson to use the {@code @SqsListener} method parameter type
+ *       instead.
+ * </ul>
+ */
+@Configuration
+public class SqsConfig {
+
+  /**
+   * Custom SqsTemplate that does not send the JavaType header. This prevents cross-service
+   * deserialization issues when event classes are defined in different packages.
+   */
+  @Bean
+  public SqsTemplate sqsTemplate(SqsAsyncClient sqsAsyncClient, ObjectMapper objectMapper) {
+    return SqsTemplate.builder()
+        .sqsAsyncClient(sqsAsyncClient)
+        .configureDefaultConverter(
+            converter -> {
+              converter.setObjectMapper(objectMapper);
+              converter.setPayloadTypeHeaderValueFunction(message -> null);
+            })
+        .build();
+  }
+
+  /**
+   * Custom SqsMessagingMessageConverter that ignores the JavaType header from incoming messages.
+   * This forces deserialization to use the @SqsListener method parameter type, which allows
+   * cross-service events with matching field structures but different package names.
+   */
+  @Bean
+  public SqsMessagingMessageConverter sqsMessagingMessageConverter(ObjectMapper objectMapper) {
+    SqsMessagingMessageConverter converter = new SqsMessagingMessageConverter();
+    converter.setObjectMapper(objectMapper);
+    converter.setPayloadTypeMapper(message -> null);
+    return converter;
+  }
+}

--- a/src/test/java/com/accountabilityatlas/videoservice/config/SqsConfigTest.java
+++ b/src/test/java/com/accountabilityatlas/videoservice/config/SqsConfigTest.java
@@ -1,0 +1,34 @@
+package com.accountabilityatlas.videoservice.config;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.awspring.cloud.sqs.operations.SqsTemplate;
+import io.awspring.cloud.sqs.support.converter.SqsMessagingMessageConverter;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+
+class SqsConfigTest {
+
+  private final SqsConfig sqsConfig = new SqsConfig();
+
+  @Test
+  void sqsTemplate_createsTemplateWithoutPayloadTypeHeader() {
+    SqsAsyncClient sqsAsyncClient = mock(SqsAsyncClient.class);
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    SqsTemplate template = sqsConfig.sqsTemplate(sqsAsyncClient, objectMapper);
+
+    assertNotNull(template);
+  }
+
+  @Test
+  void sqsMessagingMessageConverter_createsConverterThatIgnoresPayloadTypeHeader() {
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    SqsMessagingMessageConverter converter = sqsConfig.sqsMessagingMessageConverter(objectMapper);
+
+    assertNotNull(converter);
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `SqsConfig` that suppresses the `JavaType` message attribute on both the producer (`SqsTemplate`) and consumer (`SqsMessagingMessageConverter`) sides
- Prevents `ClassNotFoundException` when event classes are defined in different packages across services
- Mirrors the pattern already applied in moderation-service

## Details
Spring Cloud AWS SQS's `SqsTemplate` adds a `JavaType` message attribute containing the producer's fully-qualified class name. When video-service publishes to `video-events` and moderation-service consumes from it (or vice versa with `moderation-events`), the consumer cannot load the producer's class because the event records live in different packages.

The fix:
- **Producer side**: `setPayloadTypeHeaderValueFunction(message -> null)` suppresses the header
- **Consumer side**: `setPayloadTypeMapper(message -> null)` forces Jackson to use the `@SqsListener` method parameter type instead of the header

## Test plan
- [x] `SqsConfigTest` verifies both beans are created successfully
- [x] `./gradlew check` passes (spotless, tests, coverage)
- [ ] Deploy video-service and moderation-service; verify cross-service events deserialize correctly

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)