### PR TITLE
fix: add locationId to validation tests to avoid nondeterministic error ordering

### DIFF
--- a/src/test/java/com/accountabilityatlas/videoservice/integration/SecurityIntegrationTest.java
+++ b/src/test/java/com/accountabilityatlas/videoservice/integration/SecurityIntegrationTest.java
@@ -91,7 +91,9 @@ class SecurityIntegrationTest {
 
   @Autowired private MockMvc mockMvc;
 
-  @MockitoBean private SqsTemplate sqsTemplate;
+  @SuppressWarnings("UnusedVariable")
+  @MockitoBean
+  private SqsTemplate sqsTemplate;
 
   @MockitoBean private YouTubeService youTubeService;
 
@@ -245,9 +247,11 @@ class SecurityIntegrationTest {
         {
           "youtubeUrl": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
           "amendments": [],
-          "participants": ["POLICE"]
+          "participants": ["POLICE"],
+          "locationId": "%s"
         }
-        """;
+        """
+            .formatted(TEST_LOCATION_ID);
 
     // Act & Assert
     mockMvc
@@ -274,9 +278,11 @@ class SecurityIntegrationTest {
         {
           "youtubeUrl": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
           "amendments": ["FIRST"],
-          "participants": []
+          "participants": [],
+          "locationId": "%s"
         }
-        """;
+        """
+            .formatted(TEST_LOCATION_ID);
 
     // Act & Assert
     mockMvc


### PR DESCRIPTION
## Summary
- Add `locationId` to `emptyAmendments` and `emptyParticipants` test bodies so only the intended field fails validation (avoids nondeterministic `details[0].field` ordering when multiple fields are invalid)
- Suppress `UnusedVariable` warning on `sqsTemplate` `@MockitoBean` (needed for DI but not directly referenced)

**Root cause:** PR #34 (require locationId) added `@NotNull` to `locationId`, which meant tests without a `locationId` now had *two* validation errors instead of one. Since validation error ordering isn't guaranteed, `$.details[0].field` could be either "amendments" or "locationId".

## Test plan
- [x] `./gradlew check` passes locally (all tests green, no warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)