### PR TITLE
fix: return 204 from internal endpoints to avoid lazy init error

### DIFF
--- a/src/main/java/com/accountabilityatlas/videoservice/web/InternalVideoController.java
+++ b/src/main/java/com/accountabilityatlas/videoservice/web/InternalVideoController.java
@@ -2,7 +2,6 @@ package com.accountabilityatlas.videoservice.web;
 
 import com.accountabilityatlas.videoservice.domain.Amendment;
 import com.accountabilityatlas.videoservice.domain.Participant;
-import com.accountabilityatlas.videoservice.domain.Video;
 import com.accountabilityatlas.videoservice.domain.VideoLocation;
 import com.accountabilityatlas.videoservice.domain.VideoStatus;
 import com.accountabilityatlas.videoservice.service.VideoLocationService;
@@ -38,7 +37,7 @@ public class InternalVideoController {
   public record AddLocationRequest(UUID locationId, boolean isPrimary) {}
 
   @PutMapping("/{id}")
-  public ResponseEntity<Video> updateVideo(
+  public ResponseEntity<Void> updateVideo(
       @PathVariable UUID id, @RequestBody UpdateVideoRequest request) {
     Set<Amendment> amendments =
         request.amendments() != null
@@ -49,17 +48,16 @@ public class InternalVideoController {
             ? request.participants().stream().map(Participant::valueOf).collect(Collectors.toSet())
             : null;
 
-    Video video =
-        videoService.updateVideoInternal(id, amendments, participants, request.videoDate());
-    return ResponseEntity.ok(video);
+    videoService.updateVideoInternal(id, amendments, participants, request.videoDate());
+    return ResponseEntity.noContent().build();
   }
 
   @PutMapping("/{id}/status")
-  public ResponseEntity<Video> updateStatus(
+  public ResponseEntity<Void> updateStatus(
       @PathVariable UUID id, @RequestBody UpdateStatusRequest request) {
     VideoStatus status = VideoStatus.valueOf(request.status());
-    Video video = videoService.updateVideoStatus(id, status);
-    return ResponseEntity.ok(video);
+    videoService.updateVideoStatus(id, status);
+    return ResponseEntity.noContent().build();
   }
 
   @PostMapping("/{id}/locations")

--- a/src/test/java/com/accountabilityatlas/videoservice/web/InternalVideoControllerTest.java
+++ b/src/test/java/com/accountabilityatlas/videoservice/web/InternalVideoControllerTest.java
@@ -41,10 +41,10 @@ class InternalVideoControllerTest {
             Set.of("FIRST"), Set.of("POLICE"), LocalDate.of(2024, 1, 1));
 
     // Act
-    Video response = controller.updateVideo(id, request).getBody();
+    var response = controller.updateVideo(id, request);
 
     // Assert
-    assertThat(response).isSameAs(video);
+    assertThat(response.getStatusCode().value()).isEqualTo(204);
     verify(videoService).updateVideoInternal(eq(id), anySet(), anySet(), any());
   }
 
@@ -58,10 +58,10 @@ class InternalVideoControllerTest {
     var request = new InternalVideoController.UpdateStatusRequest("APPROVED");
 
     // Act
-    Video response = controller.updateStatus(id, request).getBody();
+    var response = controller.updateStatus(id, request);
 
     // Assert
-    assertThat(response).isSameAs(video);
+    assertThat(response.getStatusCode().value()).isEqualTo(204);
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Internal `PUT /internal/videos/{id}` and `PUT /internal/videos/{id}/status` endpoints now return `204 No Content` instead of serializing the `Video` entity
- Fixes `LazyInitializationException` on the `locations` collection that caused 500 responses
- The moderation-service auto-approval flow now completes in ~1 second instead of ~30 seconds (no more SQS retries)

## Test plan
- [x] Unit tests updated to verify 204 responses
- [x] `./gradlew check` passes
- [x] Integration test `auto-approves videos from trusted users` passes

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)