### PR TITLE
fix: exclude business exceptions from circuit breaker and retry

### DIFF
--- a/src/main/java/com/accountabilityatlas/videoservice/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/accountabilityatlas/videoservice/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.accountabilityatlas.videoservice.exception;
 
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import jakarta.validation.ConstraintViolationException;
 import java.util.List;
 import java.util.UUID;
@@ -73,6 +74,14 @@ public class GlobalExceptionHandler {
         .body(
             new ErrorResponse(
                 "AI_SERVICE_UNAVAILABLE", ex.getMessage(), null, UUID.randomUUID().toString()));
+  }
+
+  @ExceptionHandler(CallNotPermittedException.class)
+  public ResponseEntity<ErrorResponse> handleCircuitBreakerOpen(CallNotPermittedException ex) {
+    return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+        .body(
+            new ErrorResponse(
+                "SERVICE_UNAVAILABLE", ex.getMessage(), null, UUID.randomUUID().toString()));
   }
 
   @ExceptionHandler(UnauthorizedException.class)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -83,19 +83,29 @@ resilience4j:
         slidingWindowSize: 5
         failureRateThreshold: 50
         waitDurationInOpenState: 30s
+        ignoreExceptions:
+          - com.accountabilityatlas.videoservice.exception.YouTubeVideoNotFoundException
+          - com.accountabilityatlas.videoservice.exception.InvalidYouTubeUrlException
       anthropic:
         slidingWindowSize: 5
         failureRateThreshold: 50
         waitDurationInOpenState: 60s
+        ignoreExceptions:
+          - com.accountabilityatlas.videoservice.exception.MetadataExtractionException
   retry:
     instances:
       youtube:
         maxAttempts: 3
         waitDuration: 1s
         exponentialBackoffMultiplier: 2
+        ignoreExceptions:
+          - com.accountabilityatlas.videoservice.exception.YouTubeVideoNotFoundException
+          - com.accountabilityatlas.videoservice.exception.InvalidYouTubeUrlException
       anthropic:
         maxAttempts: 2
         waitDuration: 2s
+        ignoreExceptions:
+          - com.accountabilityatlas.videoservice.exception.MetadataExtractionException
   timelimiter:
     instances:
       youtube:


### PR DESCRIPTION
## Summary
- Configure `ignoreExceptions` on the YouTube and Anthropic circuit breakers so that business exceptions (`YouTubeVideoNotFoundException`, `InvalidYouTubeUrlException`, `MetadataExtractionException`) don't count as infrastructure failures
- Configure matching `ignoreExceptions` on the retry configs so these exceptions aren't retried (retrying a "video not found" won't help)
- Add `CallNotPermittedException` handler in `GlobalExceptionHandler` → returns 503 instead of generic 500

## Root Cause
The integration test "extract with unavailable video returns 422" triggers `YouTubeVideoNotFoundException`, which the circuit breaker counted as a failure. With `maxAttempts: 3` retries and `slidingWindowSize: 5`, a single video-not-found scenario produced 3 circuit breaker failures (60% > 50% threshold), opening the circuit. All subsequent YouTube API calls then failed with `CallNotPermittedException` → unhandled → 500.

Fixes #45

## Test plan
- [ ] `./gradlew check` passes (verified locally)
- [ ] Deploy video-service and re-run integration tests (`npm run test:all`) — the extract and auto-approve tests should no longer fail from circuit breaker tripping
- [ ] Verify that a 422 response from the "unavailable video" test no longer trips the circuit breaker

🤖 Generated with [Claude Code](https://claude.com/claude-code)