### PR TITLE
fix: add FOURTEENTH amendment to database check constraint

### DIFF
--- a/src/main/resources/db/migration/V6__add_fourteenth_amendment.sql
+++ b/src/main/resources/db/migration/V6__add_fourteenth_amendment.sql
@@ -1,0 +1,7 @@
+-- Add FOURTEENTH to the valid_amendment check constraint.
+-- The Fourteenth Amendment (due process, equal protection) is commonly cited
+-- in civil rights encounters alongside First, Fourth, and Fifth.
+
+ALTER TABLE videos.video_amendments
+    DROP CONSTRAINT valid_amendment,
+    ADD CONSTRAINT valid_amendment CHECK (amendment IN ('FIRST', 'SECOND', 'FOURTH', 'FIFTH', 'FOURTEENTH'));


### PR DESCRIPTION
## Summary

- Adds Flyway migration V6 to include `FOURTEENTH` in the `valid_amendment` check constraint on `video_amendments`
- The Java enum and OpenAPI spec already defined `FOURTEENTH`, but the DB constraint rejected it with a 500 error

Closes #47

## Test plan

- [x] Deploy video-service and verify Flyway migration V6 applies cleanly
- [x] Submit a video with `FOURTEENTH` in amendments — should return 201
- [x] Submit a video with only original amendments (FIRST, FOURTH, etc.) — still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)