### PR TITLE
fix: link locations before publishing VideoSubmitted event

### DIFF
--- a/src/main/java/com/accountabilityatlas/videoservice/service/VideoService.java
+++ b/src/main/java/com/accountabilityatlas/videoservice/service/VideoService.java
@@ -25,6 +25,7 @@ public class VideoService {
   private final VideoRepository videoRepository;
   private final YouTubeService youTubeService;
   private final VideoEventPublisher videoEventPublisher;
+  private final VideoLocationService videoLocationService;
 
   @Transactional(readOnly = true)
   public Video getVideo(UUID id) {
@@ -100,6 +101,12 @@ public class VideoService {
     video.setSubmittedBy(submittedBy);
 
     Video saved = videoRepository.save(video);
+
+    // Link locations before publishing event — ensures locations are committed
+    // before moderation-service callback queries for them (fixes #49)
+    for (int i = 0; i < locationIds.size(); i++) {
+      videoLocationService.addLocationInternal(saved.getId(), locationIds.get(i), i == 0);
+    }
 
     // Publish event after successful save
     videoEventPublisher.publishVideoSubmitted(saved, submitterTrustTier, locationIds);

--- a/src/main/java/com/accountabilityatlas/videoservice/web/VideoController.java
+++ b/src/main/java/com/accountabilityatlas/videoservice/web/VideoController.java
@@ -149,8 +149,6 @@ public class VideoController implements VideosApi, VideoLocationsApi {
             trustTier != null ? trustTier : "NEW",
             List.of(locationId));
 
-    videoLocationService.addLocationInternal(video.getId(), locationId, true);
-
     return ResponseEntity.status(HttpStatus.CREATED).body(toVideoDetail(video));
   }
 

--- a/src/test/java/com/accountabilityatlas/videoservice/service/VideoServiceTest.java
+++ b/src/test/java/com/accountabilityatlas/videoservice/service/VideoServiceTest.java
@@ -3,6 +3,7 @@ package com.accountabilityatlas.videoservice.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import com.accountabilityatlas.videoservice.domain.Amendment;
@@ -41,6 +42,8 @@ class VideoServiceTest {
   @Mock private YouTubeService youTubeService;
 
   @Mock private VideoEventPublisher videoEventPublisher;
+
+  @Mock private VideoLocationService videoLocationService;
 
   @InjectMocks private VideoService videoService;
 
@@ -196,6 +199,7 @@ class VideoServiceTest {
   @Test
   void createVideo_validRequest_savesMetadataAndSetsPending() {
     // Arrange
+    UUID locationId = UUID.randomUUID();
     when(youTubeService.extractVideoId("url")).thenReturn("abc123def45");
     when(videoRepository.existsByYoutubeId("abc123def45")).thenReturn(false);
 
@@ -223,13 +227,54 @@ class VideoServiceTest {
             LocalDate.of(2024, 1, 2),
             userId,
             "NEW",
-            Collections.emptyList());
+            List.of(locationId));
 
     // Assert
     assertThat(created.getYoutubeId()).isEqualTo("abc123def45");
     assertThat(created.getTitle()).isEqualTo("Title");
     assertThat(created.getStatus()).isEqualTo(VideoStatus.PENDING);
     assertThat(created.getSubmittedBy()).isEqualTo(userId);
+    verify(videoLocationService).addLocationInternal(any(), eq(locationId), eq(true));
+  }
+
+  @Test
+  void createVideo_linksLocationBeforePublishingEvent() {
+    // Arrange
+    UUID locationId = UUID.randomUUID();
+    when(youTubeService.extractVideoId("url")).thenReturn("abc123def45");
+    when(videoRepository.existsByYoutubeId("abc123def45")).thenReturn(false);
+
+    YouTubeMetadata metadata =
+        new YouTubeMetadata(
+            "abc123def45",
+            "Title",
+            "Desc",
+            "http://thumb",
+            120,
+            "channel",
+            "Channel Name",
+            Instant.parse("2024-01-01T00:00:00Z"),
+            null);
+    when(youTubeService.fetchMetadata("abc123def45")).thenReturn(metadata);
+    when(videoRepository.save(any(Video.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    // Act
+    videoService.createVideo(
+        "url",
+        Set.of(Amendment.FIRST),
+        Set.of(Participant.POLICE),
+        null,
+        userId,
+        "ADMIN",
+        List.of(locationId));
+
+    // Assert — verify ordering: location linked before event published
+    var inOrder = inOrder(videoLocationService, videoEventPublisher);
+    inOrder.verify(videoLocationService).addLocationInternal(any(), eq(locationId), eq(true));
+    inOrder
+        .verify(videoEventPublisher)
+        .publishVideoSubmitted(any(), eq("ADMIN"), eq(List.of(locationId)));
   }
 
   @Test

--- a/src/test/java/com/accountabilityatlas/videoservice/web/VideoControllerTest.java
+++ b/src/test/java/com/accountabilityatlas/videoservice/web/VideoControllerTest.java
@@ -285,7 +285,6 @@ class VideoControllerTest {
             eq(userId),
             any(),
             anyList());
-    verify(videoLocationService).addLocationInternal(video.getId(), locationId, true);
   }
 
   @Test


### PR DESCRIPTION
## Summary

Fixes #49

- **Root cause**: `VideoController.createVideo()` ran two separate transactions — `videoService.createVideo()` (saves video + publishes `VideoSubmitted` to SQS) and then `videoLocationService.addLocationInternal()` (persists `VideoLocation`). The moderation-service callback arrived in 30-60ms, before the second transaction committed, so `VideoStatusChanged` events referenced videos with no linked locations.
- **Fix**: Moved location linking into `VideoService.createVideo()` so it happens in the same transaction, *before* the `VideoSubmitted` event is published. Removed the now-redundant call from the controller.
- **Verified**: Seeded 10 videos after deploying — all 9 valid videos produced `VideoStatusChanged` events and all locations have `video_count=1`.

## Changes

- `VideoService.createVideo()`: Added `VideoLocationService` dependency, link locations before publishing event
- `VideoController.createVideo()`: Removed redundant `addLocationInternal` call
- `VideoServiceTest`: Added tests verifying location linking happens before event publish (inOrder verification)
- `VideoControllerTest`: Removed stale verification of removed controller call

## Test plan

- [x] 121 unit tests pass (`./gradlew test`)
- [x] Spotless formatting clean
- [x] Full integration suite passes (107 API + 197 E2E)
- [x] Manual verification: seed 10 videos → all 9 produce VideoStatusChanged events

🤖 Generated with [Claude Code](https://claude.com/claude-code)