### PR TITLE
feat(event): add submittedBy and dual-queue publishing (#47)

### DIFF
--- a/src/main/java/com/accountabilityatlas/videoservice/event/VideoEventPublisher.java
+++ b/src/main/java/com/accountabilityatlas/videoservice/event/VideoEventPublisher.java
@@ -26,6 +26,12 @@ public class VideoEventPublisher {
   @Value("${app.sqs.video-status-events-queue:video-status-events}")
   private String videoStatusEventsQueue;
 
+  @Value("${app.sqs.user-video-events-queue:user-video-events}")
+  private String userVideoEventsQueue;
+
+  @Value("${app.sqs.user-video-status-events-queue:user-video-status-events}")
+  private String userVideoStatusEventsQueue;
+
   /**
    * Publishes a VideoSubmitted event to the video-events queue.
    *
@@ -51,6 +57,7 @@ public class VideoEventPublisher {
         videoEventsQueue);
     try {
       sqsTemplate.send(videoEventsQueue, event);
+      sqsTemplate.send(userVideoEventsQueue, event);
       log.debug("Published VideoSubmitted event: {}", event);
     } catch (Exception e) {
       log.error(
@@ -63,17 +70,24 @@ public class VideoEventPublisher {
   }
 
   /**
-   * Publishes a VideoStatusChanged event to the video-status-events queue.
+   * Publishes a VideoStatusChanged event to the video-status-events and user-video-status-events
+   * queues.
    *
    * @param videoId the video ID
+   * @param submittedBy the submitter's user ID
    * @param locationIds list of location IDs associated with the video
    * @param previousStatus the previous status (as String to avoid cross-service coupling)
    * @param newStatus the new status
    */
   public void publishVideoStatusChanged(
-      UUID videoId, List<UUID> locationIds, String previousStatus, String newStatus) {
+      UUID videoId,
+      UUID submittedBy,
+      List<UUID> locationIds,
+      String previousStatus,
+      String newStatus) {
     VideoStatusChangedEvent event =
-        new VideoStatusChangedEvent(videoId, locationIds, previousStatus, newStatus, Instant.now());
+        new VideoStatusChangedEvent(
+            videoId, submittedBy, locationIds, previousStatus, newStatus, Instant.now());
 
     log.info(
         "Publishing VideoStatusChanged event for video {} ({} -> {}) to SQS queue {}",
@@ -83,6 +97,7 @@ public class VideoEventPublisher {
         videoStatusEventsQueue);
     try {
       sqsTemplate.send(videoStatusEventsQueue, event);
+      sqsTemplate.send(userVideoStatusEventsQueue, event);
       log.debug("Published VideoStatusChanged event: {}", event);
     } catch (Exception e) {
       log.error(

--- a/src/main/java/com/accountabilityatlas/videoservice/event/VideoStatusChangedEvent.java
+++ b/src/main/java/com/accountabilityatlas/videoservice/event/VideoStatusChangedEvent.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 
 public record VideoStatusChangedEvent(
     UUID videoId,
+    UUID submittedBy,
     List<UUID> locationIds,
     String previousStatus,
     String newStatus,

--- a/src/main/java/com/accountabilityatlas/videoservice/service/VideoService.java
+++ b/src/main/java/com/accountabilityatlas/videoservice/service/VideoService.java
@@ -183,14 +183,16 @@ public class VideoService {
     }
     Video saved = videoRepository.save(video);
 
-    // Publish status change event for location-service to update video counts
+    // Publish status change event for downstream services
     List<UUID> locationIds =
         saved.getLocations().stream().map(VideoLocation::getLocationId).toList();
-    if (!locationIds.isEmpty()
-        && ((newStatus == VideoStatus.APPROVED && previousStatus != VideoStatus.APPROVED)
-            || (previousStatus == VideoStatus.APPROVED && newStatus != VideoStatus.APPROVED))) {
+    if (previousStatus != newStatus) {
       videoEventPublisher.publishVideoStatusChanged(
-          saved.getId(), locationIds, previousStatus.name(), newStatus.name());
+          saved.getId(),
+          saved.getSubmittedBy(),
+          locationIds,
+          previousStatus.name(),
+          newStatus.name());
     }
 
     return saved;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,6 +58,8 @@ app:
     video-events-queue: video-events
     moderation-events-queue: moderation-events
     video-status-events-queue: video-status-events
+    user-video-events-queue: user-video-events
+    user-video-status-events-queue: user-video-status-events
   youtube:
     api-key: ${YOUTUBE_API_KEY:}
     base-url: https://www.googleapis.com/youtube/v3

--- a/src/test/java/com/accountabilityatlas/videoservice/event/VideoEventPublisherTest.java
+++ b/src/test/java/com/accountabilityatlas/videoservice/event/VideoEventPublisherTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -27,6 +28,8 @@ class VideoEventPublisherTest {
 
   private static final String VIDEO_EVENTS_QUEUE = "video-events";
   private static final String VIDEO_STATUS_EVENTS_QUEUE = "video-status-events";
+  private static final String USER_VIDEO_EVENTS_QUEUE = "user-video-events";
+  private static final String USER_VIDEO_STATUS_EVENTS_QUEUE = "user-video-status-events";
 
   @Mock private SqsTemplate sqsTemplate;
   @InjectMocks private VideoEventPublisher videoEventPublisher;
@@ -35,6 +38,8 @@ class VideoEventPublisherTest {
   void publishVideoSubmitted_validVideo_sendsToSqs() {
     // Arrange
     ReflectionTestUtils.setField(videoEventPublisher, "videoEventsQueue", VIDEO_EVENTS_QUEUE);
+    ReflectionTestUtils.setField(
+        videoEventPublisher, "userVideoEventsQueue", USER_VIDEO_EVENTS_QUEUE);
     Video video = new Video();
     video.setId(UUID.randomUUID());
     video.setTitle("Test Video");
@@ -57,12 +62,15 @@ class VideoEventPublisherTest {
     assertThat(event.amendments()).containsExactlyInAnyOrder("FIRST", "FOURTH");
     assertThat(event.locationIds()).isEmpty();
     assertThat(event.timestamp()).isNotNull();
+    verify(sqsTemplate).send(eq(USER_VIDEO_EVENTS_QUEUE), any(VideoSubmittedEvent.class));
   }
 
   @Test
   void publishVideoSubmitted_withLocations_includesLocationsInEvent() {
     // Arrange
     ReflectionTestUtils.setField(videoEventPublisher, "videoEventsQueue", VIDEO_EVENTS_QUEUE);
+    ReflectionTestUtils.setField(
+        videoEventPublisher, "userVideoEventsQueue", USER_VIDEO_EVENTS_QUEUE);
     Video video = new Video();
     video.setId(UUID.randomUUID());
     video.setTitle("Test Video");
@@ -80,12 +88,15 @@ class VideoEventPublisherTest {
     VideoSubmittedEvent event = captor.getValue();
     assertThat(event.submitterTrustTier()).isEqualTo("TRUSTED");
     assertThat(event.locationIds()).containsExactly(locationId);
+    verify(sqsTemplate).send(eq(USER_VIDEO_EVENTS_QUEUE), any(VideoSubmittedEvent.class));
   }
 
   @Test
   void publishVideoSubmitted_sqsFailure_rethrowsException() {
     // Arrange
     ReflectionTestUtils.setField(videoEventPublisher, "videoEventsQueue", VIDEO_EVENTS_QUEUE);
+    ReflectionTestUtils.setField(
+        videoEventPublisher, "userVideoEventsQueue", USER_VIDEO_EVENTS_QUEUE);
     Video video = new Video();
     video.setId(UUID.randomUUID());
     video.setTitle("Test Video");
@@ -102,6 +113,7 @@ class VideoEventPublisherTest {
                 videoEventPublisher.publishVideoSubmitted(
                     video, "NEW", java.util.Collections.emptyList()))
         .isSameAs(sqsException);
+    verify(sqsTemplate, times(1)).send(any(String.class), any(VideoSubmittedEvent.class));
   }
 
   @Test
@@ -109,12 +121,15 @@ class VideoEventPublisherTest {
     // Arrange
     ReflectionTestUtils.setField(
         videoEventPublisher, "videoStatusEventsQueue", VIDEO_STATUS_EVENTS_QUEUE);
+    ReflectionTestUtils.setField(
+        videoEventPublisher, "userVideoStatusEventsQueue", USER_VIDEO_STATUS_EVENTS_QUEUE);
     UUID videoId = UUID.randomUUID();
+    UUID submittedBy = UUID.randomUUID();
     UUID locationId = UUID.randomUUID();
 
     // Act
     videoEventPublisher.publishVideoStatusChanged(
-        videoId, List.of(locationId), "PENDING", "APPROVED");
+        videoId, submittedBy, List.of(locationId), "PENDING", "APPROVED");
 
     // Assert
     ArgumentCaptor<VideoStatusChangedEvent> captor =
@@ -123,10 +138,13 @@ class VideoEventPublisherTest {
 
     VideoStatusChangedEvent event = captor.getValue();
     assertThat(event.videoId()).isEqualTo(videoId);
+    assertThat(event.submittedBy()).isEqualTo(submittedBy);
     assertThat(event.locationIds()).containsExactly(locationId);
     assertThat(event.previousStatus()).isEqualTo("PENDING");
     assertThat(event.newStatus()).isEqualTo("APPROVED");
     assertThat(event.timestamp()).isNotNull();
+    verify(sqsTemplate)
+        .send(eq(USER_VIDEO_STATUS_EVENTS_QUEUE), any(VideoStatusChangedEvent.class));
   }
 
   @Test
@@ -134,13 +152,16 @@ class VideoEventPublisherTest {
     // Arrange
     ReflectionTestUtils.setField(
         videoEventPublisher, "videoStatusEventsQueue", VIDEO_STATUS_EVENTS_QUEUE);
+    ReflectionTestUtils.setField(
+        videoEventPublisher, "userVideoStatusEventsQueue", USER_VIDEO_STATUS_EVENTS_QUEUE);
     UUID videoId = UUID.randomUUID();
+    UUID submittedBy = UUID.randomUUID();
     UUID loc1 = UUID.randomUUID();
     UUID loc2 = UUID.randomUUID();
 
     // Act
     videoEventPublisher.publishVideoStatusChanged(
-        videoId, List.of(loc1, loc2), "APPROVED", "REJECTED");
+        videoId, submittedBy, List.of(loc1, loc2), "APPROVED", "REJECTED");
 
     // Assert
     ArgumentCaptor<VideoStatusChangedEvent> captor =
@@ -148,9 +169,12 @@ class VideoEventPublisherTest {
     verify(sqsTemplate).send(eq(VIDEO_STATUS_EVENTS_QUEUE), captor.capture());
 
     VideoStatusChangedEvent event = captor.getValue();
+    assertThat(event.submittedBy()).isEqualTo(submittedBy);
     assertThat(event.locationIds()).containsExactly(loc1, loc2);
     assertThat(event.previousStatus()).isEqualTo("APPROVED");
     assertThat(event.newStatus()).isEqualTo("REJECTED");
+    verify(sqsTemplate)
+        .send(eq(USER_VIDEO_STATUS_EVENTS_QUEUE), any(VideoStatusChangedEvent.class));
   }
 
   @Test
@@ -158,7 +182,10 @@ class VideoEventPublisherTest {
     // Arrange
     ReflectionTestUtils.setField(
         videoEventPublisher, "videoStatusEventsQueue", VIDEO_STATUS_EVENTS_QUEUE);
+    ReflectionTestUtils.setField(
+        videoEventPublisher, "userVideoStatusEventsQueue", USER_VIDEO_STATUS_EVENTS_QUEUE);
     UUID videoId = UUID.randomUUID();
+    UUID submittedBy = UUID.randomUUID();
 
     RuntimeException sqsException = new RuntimeException("SQS connection failed");
     when(sqsTemplate.send(eq(VIDEO_STATUS_EVENTS_QUEUE), any(VideoStatusChangedEvent.class)))
@@ -168,7 +195,8 @@ class VideoEventPublisherTest {
     assertThatThrownBy(
             () ->
                 videoEventPublisher.publishVideoStatusChanged(
-                    videoId, List.of(UUID.randomUUID()), "PENDING", "APPROVED"))
+                    videoId, submittedBy, List.of(UUID.randomUUID()), "PENDING", "APPROVED"))
         .isSameAs(sqsException);
+    verify(sqsTemplate, times(1)).send(any(String.class), any(VideoStatusChangedEvent.class));
   }
 }

--- a/src/test/java/com/accountabilityatlas/videoservice/service/VideoServiceTest.java
+++ b/src/test/java/com/accountabilityatlas/videoservice/service/VideoServiceTest.java
@@ -390,6 +390,7 @@ class VideoServiceTest {
     // Arrange
     Video video = new Video();
     video.setId(videoId);
+    video.setSubmittedBy(userId);
     video.setStatus(VideoStatus.PENDING);
     video.setLocations(Collections.emptyList());
     when(videoRepository.findByIdWithLocations(videoId)).thenReturn(Optional.of(video));
@@ -401,11 +402,12 @@ class VideoServiceTest {
 
     // Assert
     assertThat(updated.getStatus()).isEqualTo(VideoStatus.APPROVED);
-    verify(videoEventPublisher, never()).publishVideoStatusChanged(any(), any(), any(), any());
+    verify(videoEventPublisher)
+        .publishVideoStatusChanged(videoId, userId, Collections.emptyList(), "PENDING", "APPROVED");
   }
 
   @Test
-  void updateVideoStatus_nonApprovedTransition_doesNotPublishEvent() {
+  void updateVideoStatus_pendingToRejected_publishesStatusChangedEvent() {
     // Arrange
     UUID locationId = UUID.randomUUID();
     VideoLocation videoLocation = new VideoLocation();
@@ -413,6 +415,7 @@ class VideoServiceTest {
 
     Video video = new Video();
     video.setId(videoId);
+    video.setSubmittedBy(userId);
     video.setStatus(VideoStatus.PENDING);
     video.setLocations(List.of(videoLocation));
     when(videoRepository.findByIdWithLocations(videoId)).thenReturn(Optional.of(video));
@@ -423,7 +426,8 @@ class VideoServiceTest {
     videoService.updateVideoStatus(videoId, VideoStatus.REJECTED, null);
 
     // Assert
-    verify(videoEventPublisher, never()).publishVideoStatusChanged(any(), any(), any(), any());
+    verify(videoEventPublisher)
+        .publishVideoStatusChanged(videoId, userId, List.of(locationId), "PENDING", "REJECTED");
   }
 
   @Test
@@ -435,6 +439,7 @@ class VideoServiceTest {
 
     Video video = new Video();
     video.setId(videoId);
+    video.setSubmittedBy(userId);
     video.setStatus(VideoStatus.PENDING);
     video.setLocations(List.of(videoLocation));
     when(videoRepository.findByIdWithLocations(videoId)).thenReturn(Optional.of(video));
@@ -446,7 +451,7 @@ class VideoServiceTest {
 
     // Assert
     verify(videoEventPublisher)
-        .publishVideoStatusChanged(videoId, List.of(locationId), "PENDING", "APPROVED");
+        .publishVideoStatusChanged(videoId, userId, List.of(locationId), "PENDING", "APPROVED");
   }
 
   @Test
@@ -458,6 +463,7 @@ class VideoServiceTest {
 
     Video video = new Video();
     video.setId(videoId);
+    video.setSubmittedBy(userId);
     video.setStatus(VideoStatus.APPROVED);
     video.setLocations(List.of(videoLocation));
     when(videoRepository.findByIdWithLocations(videoId)).thenReturn(Optional.of(video));
@@ -469,7 +475,7 @@ class VideoServiceTest {
 
     // Assert
     verify(videoEventPublisher)
-        .publishVideoStatusChanged(videoId, List.of(locationId), "APPROVED", "REJECTED");
+        .publishVideoStatusChanged(videoId, userId, List.of(locationId), "APPROVED", "REJECTED");
   }
 
   @Test
@@ -479,6 +485,7 @@ class VideoServiceTest {
     video.setId(videoId);
     video.setStatus(VideoStatus.PENDING);
     video.setLocations(Collections.emptyList());
+    video.setSubmittedBy(userId);
     when(videoRepository.findByIdWithLocations(videoId)).thenReturn(Optional.of(video));
     when(videoRepository.save(any(Video.class)))
         .thenAnswer(invocation -> invocation.getArgument(0));
@@ -489,6 +496,8 @@ class VideoServiceTest {
     // Assert
     assertThat(updated.getStatus()).isEqualTo(VideoStatus.REJECTED);
     assertThat(updated.getRejectionReason()).isEqualTo("OFF_TOPIC");
+    verify(videoEventPublisher)
+        .publishVideoStatusChanged(videoId, userId, Collections.emptyList(), "PENDING", "REJECTED");
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Add `submittedBy` UUID field to `VideoStatusChangedEvent` so downstream consumers know whose stats to update
- Implement dual-queue publishing: events go to both original queues and dedicated user-service queues
- Broaden publishing condition from APPROVED-only transitions to any status change

Closes #47

## Changes
- `VideoStatusChangedEvent.java` — added `submittedBy` field
- `VideoEventPublisher.java` — dual-queue publishing to `user-video-events` and `user-video-status-events`
- `VideoService.java` — broadened condition: `previousStatus != newStatus`
- `application.yml` — new queue properties
- Tests updated for dual-queue assertions and `submittedBy`

## Test plan
- [x] All unit tests pass (`./gradlew unitTest`)
- [x] Full integration test suite passed (119 API + 252 E2E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)